### PR TITLE
fix: use poetry to run main.py

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/configure-pages@v4
       
       - name: Build with Python Jinja
-        run: python main.py
+        run: poetry run python main.py
       
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Use poetry to ensure that the correct dependencies are used when running the Python script. This eliminates potential issues that might arise from using a different Python environment or outdated dependencies.