### PR TITLE
fix: broken ionic icons

### DIFF
--- a/src/jinja/index.j2
+++ b/src/jinja/index.j2
@@ -34,7 +34,7 @@
   <!--- JS --->
   <script src="./src/js/script.js"></script>
   <!--- IONICONS --->
-  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Replace Ionicons CDN with jsDelivr to fix broken icons